### PR TITLE
Allow asserting on CapturedLog values

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,19 +53,20 @@
 //! ```
 
 extern crate log;
-use log::{Log, Record, Metadata, LevelFilter, Level};
+use log::{Level, LevelFilter, Log, Metadata, Record};
 use std::cell::RefCell;
 use std::sync::{Once, ONCE_INIT};
 
 /// A captured call to the logging system. A `Vec` of these is passed
 /// to the closure supplied to the `validate()` function.
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CapturedLog {
     /// The formatted log message.
     pub body: String,
     /// The level.
     pub level: Level,
     /// The target.
-    pub target: String
+    pub target: String,
 }
 
 thread_local!(static LOG_RECORDS: RefCell<Vec<CapturedLog>> = RefCell::new(Vec::with_capacity(3)));
@@ -73,30 +74,28 @@ thread_local!(static LOG_RECORDS: RefCell<Vec<CapturedLog>> = RefCell::new(Vec::
 struct TestingLogger {}
 
 impl Log for TestingLogger {
-
     #[allow(unused_variables)]
     fn enabled(&self, metadata: &Metadata) -> bool {
         true // capture all log levels
     }
 
-    fn log(& self, record: &Record) {
-        LOG_RECORDS.with( |records| {
+    fn log(&self, record: &Record) {
+        LOG_RECORDS.with(|records| {
             let captured_record = CapturedLog {
-                body: format!("{}",record.args()),
+                body: format!("{}", record.args()),
                 level: record.level(),
-                target: record.target().to_string()
+                target: record.target().to_string(),
             };
             records.borrow_mut().push(captured_record);
         });
     }
 
     fn flush(&self) {}
-
 }
 
 static FIRST_TEST: Once = ONCE_INIT;
 
-static TEST_LOGGER: TestingLogger = TestingLogger{};
+static TEST_LOGGER: TestingLogger = TestingLogger {};
 
 /// Prepare the `testing_logger` to capture log messages for a test.
 ///
@@ -104,11 +103,12 @@ static TEST_LOGGER: TestingLogger = TestingLogger{};
 /// This function will install an internal `TestingLogger` as the logger if not already done so, and initialise
 /// its thread local storage for a new test.
 pub fn setup() {
-    FIRST_TEST.call_once( || {
-        log::set_logger(&TEST_LOGGER).map(|()|
-        log::set_max_level(LevelFilter::Trace)).unwrap();
+    FIRST_TEST.call_once(|| {
+        log::set_logger(&TEST_LOGGER)
+            .map(|()| log::set_max_level(LevelFilter::Trace))
+            .unwrap();
     });
-    LOG_RECORDS.with( |records| {
+    LOG_RECORDS.with(|records| {
         records.borrow_mut().truncate(0);
     });
 }
@@ -117,9 +117,63 @@ pub fn setup() {
 ///
 /// the `asserter` closure can check the number, body, target and level
 /// of captured log events. As a side effect, the records are cleared.
-pub fn validate<F>(asserter: F)  where F: Fn(&Vec<CapturedLog>) {
-    LOG_RECORDS.with( |records| {
+pub fn validate<F>(asserter: F)
+where
+    F: Fn(&Vec<CapturedLog>),
+{
+    LOG_RECORDS.with(|records| {
         asserter(&records.borrow());
         records.borrow_mut().truncate(0);
     });
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn captures_logs() {
+        setup();
+
+        log::trace!("trace");
+        log::debug!("debug");
+        log::info!("info");
+        log::warn!("warn");
+        log::error!("error");
+
+        const TARGET: &'static str = "testing_logger::test";
+
+        validate(|records| {
+            assert_eq!(
+                records,
+                &[
+                    CapturedLog {
+                        body: "trace".to_string(),
+                        level: Level::Trace,
+                        target: TARGET.to_string(),
+                    },
+                    CapturedLog {
+                        body: "debug".to_string(),
+                        level: Level::Debug,
+                        target: TARGET.to_string(),
+                    },
+                    CapturedLog {
+                        body: "info".to_string(),
+                        level: Level::Info,
+                        target: TARGET.to_string(),
+                    },
+                    CapturedLog {
+                        body: "warn".to_string(),
+                        level: Level::Warn,
+                        target: TARGET.to_string(),
+                    },
+                    CapturedLog {
+                        body: "error".to_string(),
+                        level: Level::Error,
+                        target: TARGET.to_string(),
+                    },
+                ]
+            );
+        })
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,15 +59,24 @@ use std::sync::{Once, ONCE_INIT};
 
 /// A captured call to the logging system. A `Vec` of these is passed
 /// to the closure supplied to the `validate()` function.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct CapturedLog {
+#[derive(Clone, Debug)]
+pub struct CapturedLog<S = String> {
     /// The formatted log message.
-    pub body: String,
+    pub body: S,
     /// The level.
     pub level: Level,
     /// The target.
-    pub target: String,
+    pub target: S,
 }
+
+impl<S1: PartialEq<S2>, S2: PartialEq> PartialEq<CapturedLog<S2>> for CapturedLog<S1> {
+    fn eq(&self, other: &CapturedLog<S2>) -> bool {
+        self.body == other.body && self.level == other.level && self.target == other.target
+    }
+}
+
+impl<S: Eq> Eq for CapturedLog<S> {}
+
 
 thread_local!(static LOG_RECORDS: RefCell<Vec<CapturedLog>> = RefCell::new(Vec::with_capacity(3)));
 
@@ -148,29 +157,29 @@ mod test {
                 records,
                 &[
                     CapturedLog {
-                        body: "trace".to_string(),
+                        body: "trace",
                         level: Level::Trace,
-                        target: TARGET.to_string(),
+                        target: TARGET,
                     },
                     CapturedLog {
-                        body: "debug".to_string(),
+                        body: "debug",
                         level: Level::Debug,
-                        target: TARGET.to_string(),
+                        target: TARGET,
                     },
                     CapturedLog {
-                        body: "info".to_string(),
+                        body: "info",
                         level: Level::Info,
-                        target: TARGET.to_string(),
+                        target: TARGET,
                     },
                     CapturedLog {
-                        body: "warn".to_string(),
+                        body: "warn",
                         level: Level::Warn,
-                        target: TARGET.to_string(),
+                        target: TARGET,
                     },
                     CapturedLog {
-                        body: "error".to_string(),
+                        body: "error",
                         level: Level::Error,
-                        target: TARGET.to_string(),
+                        target: TARGET,
                     },
                 ]
             );


### PR DESCRIPTION
Implement `Debug` and `PartialEq` so that tests can use `assert_eq!` to compare `CapturedLog` values, or assert that a `Vec<CapturedLog>` is equal to `&[]`. Template `CapturedLog` over the string field type so that it can be constructed with `&'static str`s, and allow equality checks against captured instances. Add a test demonstrating these features.

Fixes #1